### PR TITLE
Hotfix/awk gpu info regex fix

### DIFF
--- a/awk/parse_claymore_gpu_info.awk
+++ b/awk/parse_claymore_gpu_info.awk
@@ -1,7 +1,7 @@
 # USED BY update-rig-info.sh
 
 BEGIN {
-	FS = "[ ,:()]"
+	FS = "(: )|(, )"
 	GPU_INDEX=0
 }
 
@@ -10,10 +10,13 @@ BEGIN {
 
 # READ GPU INFO E.G.
 # GPU #0: Ellesmere, 8192 MB available, 36 compute units
+# GPU #0: GeForce GTX 1060 6GB, 6144 MB available, 10 compute units, capability: 6.1
 /^GPU #/ { 
-	gpu[GPU_INDEX,"MODEL"]=$4
-	gpu[GPU_INDEX,"MEMORY"]=$6
-	gpu[GPU_INDEX,"PROC"]=$10
+	gpu[GPU_INDEX,"MODEL"]=$2
+	gpu[GPU_INDEX,"MEMORY"]=$3
+	sub(/ MB available/,"",gpu[GPU_INDEX,"MEMORY"])	
+	gpu[GPU_INDEX,"PROC"]=$4A
+	sub(/ compute units/,"",gpu[GPU_INDEX,"PROC"])
 	GPU_INDEX++
 }
 

--- a/awk/parse_claymore_gpu_info.awk
+++ b/awk/parse_claymore_gpu_info.awk
@@ -1,7 +1,7 @@
 # USED BY update-rig-info.sh
 
 BEGIN {
-	FS = "(: )|(, )"
+	FS = "[ ,:()]"
 	GPU_INDEX=0
 }
 
@@ -11,11 +11,9 @@ BEGIN {
 # READ GPU INFO E.G.
 # GPU #0: Ellesmere, 8192 MB available, 36 compute units
 /^GPU #/ { 
-	gpu[GPU_INDEX,"MODEL"]=$2
-	gpu[GPU_INDEX,"MEMORY"]=$3
-	sub(/ MB available/,"",gpu[GPU_INDEX,"MEMORY"])	
-	gpu[GPU_INDEX,"PROC"]=$4A
-	sub(/ compute units/,"",gpu[GPU_INDEX,"PROC"])
+	gpu[GPU_INDEX,"MODEL"]=$4
+	gpu[GPU_INDEX,"MEMORY"]=$6
+	gpu[GPU_INDEX,"PROC"]=$10
 	GPU_INDEX++
 }
 

--- a/awk/parse_claymore_gpu_info.awk
+++ b/awk/parse_claymore_gpu_info.awk
@@ -1,7 +1,7 @@
 # USED BY update-rig-info.sh
 
 BEGIN {
-	FS = "[ ,:()]"
+	FS = "(: )|(, )"
 	GPU_INDEX=0
 }
 
@@ -11,9 +11,11 @@ BEGIN {
 # READ GPU INFO E.G.
 # GPU #0: Ellesmere, 8192 MB available, 36 compute units
 /^GPU #/ { 
-	gpu[GPU_INDEX,"MODEL"]=$4
-	gpu[GPU_INDEX,"MEMORY"]=$6
-	gpu[GPU_INDEX,"PROC"]=$10
+	gpu[GPU_INDEX,"MODEL"]=$2
+	gpu[GPU_INDEX,"MEMORY"]=$3
+	sub(/ MB available/,"",gpu[GPU_INDEX,"MEMORY"])	
+	gpu[GPU_INDEX,"PROC"]=$4A
+	sub(/ compute units/,"",gpu[GPU_INDEX,"PROC"])
 	GPU_INDEX++
 }
 

--- a/awk/parse_claymore_status.awk
+++ b/awk/parse_claymore_status.awk
@@ -58,10 +58,12 @@ BEGIN {
 /^  (DCR|SC|LBC|PASC):/ {
         #print $5,$9,$13,$17,$21,$25
 	gpu_field=6
+	_index=0
 	while ( gpu_field < NF ) {
-		_index = gpu_field/6 - 1
+#               _index = gpu_field/6 - 1
 		gpu[_index,"HASHRATE_DCOIN"]=$gpu_field
 		gpu_field+=4	
+		_index++
 	}
 }
 


### PR DESCRIPTION
My string was slightly different than yours which was causing the awk script to fail at pulling down my gpu info.  This should work for most out there, but I don't have a big farm to test.