### PR TITLE
Hotfix/nanopool 

### DIFF
--- a/monitors/pool-nanopool.sh
+++ b/monitors/pool-nanopool.sh
@@ -43,6 +43,20 @@ else
 	DATA_BINARY="${DATA_BINARY}"$'\n'"${LINE}"
 fi
 
+########### Query worker stats from existing generalinfo API call ############
+if [ "$API_STATUS" == "false" ]; then
+	echo "NO DATA FOUND"
+else
+
+	MEASUREMENT="workers_stats"
+	WORKER_TAG_AND_FIELDS=`echo $GENERALINFO_OUTPUT | jq -r '.data | .workers | .[] | "worker_id=\(.id) avg_hr_24h=\(.avg_h24),hr=\(.hashrate),shares=\(.rating),lastshare=\(.lastShare)"' `
+	while read -r WORKER_TAG FIELDS; do
+		TAGS="pool_type=${POOL_TYPE},crypto=${CRYPTO},label=${LABEL},${WORKER_TAG}"
+		LINE="${MEASUREMENT},${TAGS} ${FIELDS} ${RUN_TIME}"
+		DATA_BINARY="${DATA_BINARY}"$'\n'"${LINE}"
+	done<<< "$WORKER_TAG_AND_FIELDS"
+fi
+
 ############ Query network stats API ############
 # Query average block time
 AVERAGEBLOCKTIME_URL="${BASE_API_URL}/network/avgblocktime"
@@ -85,25 +99,25 @@ if [ "$API_STATUS" == "true" ] && [ "$API_STATUS_2" == "true" ]; then
 fi
 
 ############ Query workers ############
-WORKERS_URL="${BASE_API_URL}/avghashrateworkers/${WALLET_ADDR}/24"
-WORKERS_OUTPUT=`curl -s "${WORKERS_URL}" | jq -r '.'`
-
-if (( DEBUG == 1 )); then
-	echo "curl \"$WORKERS_URL\""
-	echo $WORKERS_OUTPUT  | jq -r '.'
-fi
-
-if [ "$WORKERS_OUTPUT" == "" ]; then
-	echo "NO DATA FOUND"
-else
-	MEASUREMENT="workers_stats"
-	WORKER_TAG_AND_FIELDS=`echo $WORKERS_OUTPUT | jq -r '.data[] | "worker_id=\(.worker) avg_hr_24h=\(.hashrate)"' `
-	while read -r WORKER_TAG FIELDS; do
-		TAGS="pool_type=${POOL_TYPE},crypto=${CRYPTO},label=${LABEL},${WORKER_TAG}"
-		LINE="${MEASUREMENT},${TAGS} ${FIELDS} ${RUN_TIME}"
-		DATA_BINARY="${DATA_BINARY}"$'\n'"${LINE}"
-	done<<< "$WORKER_TAG_AND_FIELDS"
-fi
+#WORKERS_URL="${BASE_API_URL}/avghashrateworkers/${WALLET_ADDR}/24"
+#WORKERS_OUTPUT=`curl -s "${WORKERS_URL}" | jq -r '.'`
+#
+#if (( DEBUG == 1 )); then
+#	echo "curl \"$WORKERS_URL\""
+#	echo $WORKERS_OUTPUT  | jq -r '.'
+#fi
+#
+#if [ "$WORKERS_OUTPUT" == "" ]; then
+#	echo "NO DATA FOUND"
+#else
+#	MEASUREMENT="workers_stats"
+#	WORKER_TAG_AND_FIELDS=`echo $WORKERS_OUTPUT | jq -r '.data[] | "worker_id=\(.worker) avg_hr_24h=\(.hashrate)"' `
+#	while read -r WORKER_TAG FIELDS; do
+#		TAGS="pool_type=${POOL_TYPE},crypto=${CRYPTO},label=${LABEL},${WORKER_TAG}"
+#		LINE="${MEASUREMENT},${TAGS} ${FIELDS} ${RUN_TIME}"
+#		DATA_BINARY="${DATA_BINARY}"$'\n'"${LINE}"
+#	done<<< "$WORKER_TAG_AND_FIELDS"
+#fi
 
 ############ Query payouts ############
 PAYMENTS_URL="${BASE_API_URL}/payments/${WALLET_ADDR}"
@@ -122,7 +136,7 @@ if [ "$PAYMENTS_OUTPUT" == "" ]; then
 else
 	MEASUREMENT="pool_payments"
 	TAGS="pool_type=${POOL_TYPE},crypto=${CRYPTO},label=${LABEL}"
-	FIELDS_AND_TIME=`echo $PAYMENTS_OUTPUT | jq -r '. | "amount=\(.amount),txHash=\"\(.txHash)\" \(.date)000000000"'`
+	FIELDS_AND_TIME=`echo $PAYMENTS_OUTPUT | jq -r '. | "amount=\(.amount),txHash=\"\(.txHash)\",confirmed=\(.confirmed) \(.date)000000000"'`
 	while read -r _FIELD; do
 		LINE="${MEASUREMENT},${TAGS} ${_FIELD}"
 		RECORD_TIME=`echo ${LINE} | awk '{ print substr($NF,1,11) }' `

--- a/monitors/pool-nanopool.sh
+++ b/monitors/pool-nanopool.sh
@@ -47,7 +47,6 @@ fi
 if [ "$API_STATUS" == "false" ]; then
 	echo "NO DATA FOUND"
 else
-
 	MEASUREMENT="workers_stats"
 	WORKER_TAG_AND_FIELDS=`echo $GENERALINFO_OUTPUT | jq -r '.data | .workers | .[] | "worker_id=\(.id) avg_hr_24h=\(.avg_h24),hr=\(.hashrate),shares=\(.rating),lastshare=\(.lastShare)"' `
 	while read -r WORKER_TAG FIELDS; do


### PR DESCRIPTION
a couple of fixes to the nanopool module

1. You were duplicating efforts between the general /user/ stats and the worker stats.  The user api returns everything you need.
2. I added the shares (called rating) and hashrate per worker for the workers measurement from the exsiting general call.
3. I added confirmed into the pool_payments measurement.    I'm getting double entries because I'm guessing that once it becomes confirmed the date changes and it writes a new entry in the database.  I'm ok with this is I can weed out the payments that are not confirmed.  Multiple ways to handle this, but I think knowing if it's confirmed or not is useful.