### PR TITLE
feature/miner-claymore-timeout

### DIFF
--- a/monitors/miner-claymore.sh
+++ b/monitors/miner-claymore.sh
@@ -10,13 +10,23 @@ if (( DEBUG == 1 )); then
 	echo "$TIME $CLAYMORE_READOUT"
 fi
 
+# check if no response from w3m
+if [ "$CLAYMORE_READOUT" == "" ]; then
+        echo "w3m FAILED"
+        DATA_BINARY="miner_system_claymore,rig_id=${RIG_ID},coin=${COIN_LABEL},dcoin=${DCOIN_LABEL},miner=claymore installed_gpus=${INSTALLED_GPUS},active_gpus=-1,target_hr=${TARGET_HR},total_hr=-1,total_hr_dcoin=-1,target_hr_dcoin=${TARGET_HR_DCOIN}"
+        #curl -s -i -m 5 -XPOST 'http://localhost:8086/write?db=rigdata' --data-binary "${DATA_BINARY}"
+else
+
+
 # parse miner output, prepare data for influxdb ingest and filter out null tags, fields
 
-DATA_POINTS=`awk -f ${BASE_DIR}/awk/parse_claymore_status.awk \
-	-v time=${TIME} rig_id=${RIG_ID} coin=${COIN_LABEL} dcoin=${DCOIN_LABEL} installed_gpus=${INSTALLED_GPUS} \
-	target_hr_eth=${TARGET_HR} target_hr_dcoin=${TARGET_HR_DCOIN} \
-	<<< "$CLAYMORE_READOUT" `
-DATA_BINARY=`echo "${DATA_POINTS}" |  sed -e 's/[a-z0-9_]\+=,//g' -e 's/,[a-z0-9_]\+= $//g'`
+	DATA_POINTS=`awk -f ${BASE_DIR}/awk/parse_claymore_status.awk \
+		-v time=${TIME} rig_id=${RIG_ID} coin=${COIN_LABEL} dcoin=${DCOIN_LABEL} installed_gpus=${INSTALLED_GPUS} \
+		target_hr_eth=${TARGET_HR} target_hr_dcoin=${TARGET_HR_DCOIN} \
+		<<< "$CLAYMORE_READOUT" `
+	DATA_BINARY=`echo "${DATA_POINTS}" |  sed -e 's/[a-z0-9_]\+=,//g' -e 's/,[a-z0-9_]\+= $//g'`
+fi
+
 if (( DEBUG == 1 )); then
         echo "$DATA_BINARY"
 fi


### PR DESCRIPTION
Here is my suggestion when the script cannot connect.  I'm already doing this in miner_ewbf..sh.  I'm not sure what values need to be written when this happens?  I write out the static rig values, but none of the additional measured values.  Let me know what you think.  The three values that get -1 are, active_gpus, total_hr, and total_hr_dcoin.  miner_gpu_claymore is not written at all, but we could use the "installed_gpus" to write out that number of lines with -1 as well.  let me know your thoughts.