### PR TITLE
hotfix/rig-monitor-multiple

### DIFF
--- a/awk/parse_claymore_status.awk
+++ b/awk/parse_claymore_status.awk
@@ -172,7 +172,7 @@ END {
         print "miner_system,rig_id=" rig_id ",miner=claymore,coin=" coin ",dcoin=" dcoin " " "installed_gpus=" installed_gpus ",active_gpus=" NUM_GPUS ",target_hr="target_hr ",total_hr=" total_hr",avg_hr_1m=" avg_hr_1m ",total_shares=" total_shares ",rej_shares=" rej_shares ",target_hr_dcoin=" target_hr_dcoin ",total_hr_dcoin=" total_hr_dcoin ",avg_hr_1m_dcoin=" avg_hr_1m_dcoin ",total_shares_dcoin=" total_shares_dcoin ",rej_shares_dcoin=" rej_shares_dcoin ",mining_time=\"" mining_time "\""
 
         for ( gpu_id = 0; gpu_id < NUM_GPUS; gpu_id++ ) {
-        	print "miner_gpu,rig_id=" rig_id ",gpu_id=" gpu_id ",gpu_specs=" gpu[gpu_id,"SPECS"] " " "gpu_hr=" gpu[gpu_id,"HR"] ",gpu_shares=" gpu[gpu_id,"SHARES"] ",gpu_inc_shares=" gpu[gpu_id,"INC_SHARES"] ",gpu_hr_dcoin=" gpu[gpu_id,"HR_DCOIN"] ",gpu_shares_dcoin=" gpu[gpu_id,"SHARES_DCOIN"] ",gpu_inc_shares_dcoin="  gpu[gpu_id,"INC_SHARES_DCOIN"] ",gpu_max_temp=" gpu_max_temp ",gpu_temp=" gpu[gpu_id,"TEMP"] ",gpu_fan=" gpu[gpu_id,"FAN"]
+        	print "miner_gpu,rig_id=" rig_id ",miner=claymore,gpu_id=" gpu_id ",gpu_specs=" gpu[gpu_id,"SPECS"] " " "gpu_hr=" gpu[gpu_id,"HR"] ",gpu_shares=" gpu[gpu_id,"SHARES"] ",gpu_inc_shares=" gpu[gpu_id,"INC_SHARES"] ",gpu_hr_dcoin=" gpu[gpu_id,"HR_DCOIN"] ",gpu_shares_dcoin=" gpu[gpu_id,"SHARES_DCOIN"] ",gpu_inc_shares_dcoin="  gpu[gpu_id,"INC_SHARES_DCOIN"] ",gpu_max_temp=" gpu_max_temp ",gpu_temp=" gpu[gpu_id,"TEMP"] ",gpu_fan=" gpu[gpu_id,"FAN"]
         }
 	
 	if (TRACE != 0) { 

--- a/monitors/miner-ewbf.sh
+++ b/monitors/miner-ewbf.sh
@@ -21,7 +21,7 @@ fi
 # parse miner output, prepare data for influxdb ingest and filter out null tags, fields
 if [ "$EWBF_READOUT" == "" ]; then
 	echo "CURL FAILED"
-	DATA_BINARY="miner_system,rig_id=${RIG_ID},miner=ewbf,coin=${COIN_LABEL} installed_gpus=${INSTALLED_GPUS}i,active_gpus=-1i,target_hr=${TARGET_HR},total_hr=-1,max_power=${MAX_POWER}" 
+	DATA_BINARY="miner_system,rig_id=${RIG_ID},miner=ewbf,coin=${COIN_LABEL} installed_gpus=${INSTALLED_GPUS},active_gpus=-1,target_hr=${TARGET_HR},total_hr=-1,max_power=${MAX_POWER}" 
 	curl -s -i -m 5 -XPOST 'http://localhost:8086/write?db=rigdata' --data-binary "${DATA_BINARY}"
 
 else
@@ -37,8 +37,8 @@ else
 
 
         DATA_POINTS_GPU=`awk -v RIGNAME=${RIG_ID} -v coin=${COIN_LABEL} -F"," \
-		        '{print "miner_gpu,rig_id="RIGNAME",gpu_id="$1",gpu_specs="$8",coin=ZEC "\
-		        "gpu_hr="$2",gpu_shares="$3"i,gpu_rej_shares="$4"i,gpu_temp="$5"i,gpu_power="$6"i,gpu_status="$7"i"}' \
+		        '{print "miner_gpu,rig_id="RIGNAME",gpu_id="$1",gpu_specs="$8",coin=ZEC,miner=ewbf "\
+		        "gpu_hr="$2",gpu_shares="$3",gpu_rej_shares="$4",gpu_temp="$5",gpu_power="$6",gpu_status="$7}' \
 			<<< "$DATA_POINTS_GPU_CSV"`
 
 	# Math to create system stats, ewbf does not report it
@@ -48,7 +48,7 @@ else
 	RIG_REJ=`awk -F"," '{x+=$4}END{print x}' <<< "$DATA_POINTS_GPU_CSV"`
 	RIG_POWER=`awk -F"," '{x+=$6}END{print x}' <<< "$DATA_POINTS_GPU_CSV"`
 	RIG_UPTIME=`awk -F"," -v TIME=${TIME} '{printf "%i",TIME-$1}' <<< "$RIG_START"`
-	DATA_POINTS_RIG="miner_system,rig_id=${RIG_ID},miner=ewbf,coin=${COIN_LABEL} installed_gpus=${INSTALLED_GPUS}i,active_gpus=${RIG_GPU_HEALTH}i,target_hr=${TARGET_HR},total_hr=${RIG_HR},total_shares=${RIG_SHARES}i,rej_shares=${RIG_REJ}i,max_power=${MAX_POWER},power_usage=${RIG_POWER},mining_time=${RIG_UPTIME}i"
+	DATA_POINTS_RIG="miner_system,rig_id=${RIG_ID},miner=ewbf,coin=${COIN_LABEL} installed_gpus=${INSTALLED_GPUS},active_gpus=${RIG_GPU_HEALTH},target_hr=${TARGET_HR},total_hr=${RIG_HR},total_shares=${RIG_SHARES},rej_shares=${RIG_REJ},max_power=${MAX_POWER},power_usage=${RIG_POWER},mining_time=\"${RIG_UPTIME}\""
 
 	DATA_POINTS=${DATA_POINTS_RIG}$'\n'${DATA_POINTS_GPU}
 

--- a/monitors/miner-sgminer.sh
+++ b/monitors/miner-sgminer.sh
@@ -26,7 +26,7 @@ if (( CONNECTION_ERROR == 0 ));then
 
 	GPU_TAG_AND_FIELDS=`echo $SGMINER_READOUT | jq -r '.devs[0].DEVS[] | "gpu_id=\(.GPU) gpu_online=\(.Status),gpu_hr=\(."MHS 5s"),gpu_shares=\(.Accepted),gpu_rej_shares=\(.Rejected),gpu_hw_erros=\(."Hardware Errors"),gpu_raw_intensity=\(.RawIntensity),gpu_temp=\(.Temperature),gpu_fan=\(."Fan Percent")"' | sed -e 's/gpu_online=Alive/gpu_online=1/g' `
 	while read -r _GPU_TAG_AND_FIELDS;do
-		LINE="miner_gpu,rig_id=${RIG_ID},$_GPU_TAG_AND_FIELDS $TIME"
+		LINE="miner_gpu,miner=sgminer,rig_id=${RIG_ID},$_GPU_TAG_AND_FIELDS $TIME"
 		DATA_BINARY="${DATA_BINARY}"$'\n'"${LINE}"
 	done <<< "$GPU_TAG_AND_FIELDS"
 else

--- a/rig-monitor.sh
+++ b/rig-monitor.sh
@@ -46,10 +46,12 @@ do
 		echo "rig info in conf file: $RIG_LINE"
 	fi
 	. ${BASE_DIR}/monitors/miner-${MINER,,}.sh
+
+	# write out each rig to database
+	echo "$DATA_BINARY" > tmp/rig_binary_data.tmp
+	curl -i -XPOST 'http://'${INFLUX_HOST}':8086/write?db='${INFLUX_DB} --data-binary @tmp/rig_binary_data.tmp
 done
 
-echo "$DATA_BINARY" > tmp/rig_binary_data.tmp
-curl -i -XPOST 'http://'${INFLUX_HOST}':8086/write?db='${INFLUX_DB} --data-binary @tmp/rig_binary_data.tmp
 
 IFS=$SAVEIFS
 rm ${BASE_DIR}/run/RIG_LOCK 


### PR DESCRIPTION
Multiple fixes:

rig-monitor: We were only writing out the last binary data in the rig_list, not each one.  I've put the write out in the loop and it works, but we could collect all rig data first to a tmp dir and then write out to db afterword if you prefer, might be more efficient long term?

miners - added miner tag to miner_gpu measurement.  I think it needs to be here if we're removing the [module] name from the measurement?

miner-ewbf - removed my integer "i" options from the database writes.  If we're removing the [module] in the measurement then all of our definitions must match up or it will error on the write.  I had to fix a couple of mismatches here.  Haven't tested extensively and I don't have sgminer at the moment, so we'll need that tested.